### PR TITLE
FIX: Fix for MsgPack in newer versions of GCC

### DIFF
--- a/src/PPNet.h
+++ b/src/PPNet.h
@@ -6,6 +6,8 @@
 #include <variant>
 #include <iostream>
 #include <string>
+#include <cstdint>
+#include <stddef.h>
 
 #include <MsgPack.h>
 #include <Stream.h>


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Added `#include <cstdint>` and `#include <stddef.h>` in `src/PPNet.h` to fix compatibility issues with MsgPack in newer versions of GCC.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PPNet.h</strong><dd><code>Include necessary headers for MsgPack compatibility with newer GCC</code></dd></summary>
<hr>

src/PPNet.h

<li>Added <code>#include <cstdint></code> and <code>#include <stddef.h></code> to ensure compatibility with newer GCC <br>versions.<br>


</details>


  </td>
  <td><a href="https://github.com/PagoPlus/ppnet/pull/9/files#diff-47ba05ea5fd40de66e82a961bcb170bdece9b6aafb92fa7b57814c26b12f3770">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

